### PR TITLE
CI Setup things

### DIFF
--- a/.github/workflows/jenkins_build.yml
+++ b/.github/workflows/jenkins_build.yml
@@ -1,0 +1,17 @@
+name: Trigger Jenkins dev CI
+
+on: [pull_request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Main
+      uses: appleboy/jenkins-action@master
+      if: github.event.pull_request.merged
+      with:
+        url: "https://ci.boxofficeinitiative.dev/"
+        user: "github"
+        token: ${{ secrets.JENKINS_TOKEN }}
+        job: "Backend-API"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+WORKDIR /app
+
+# copy csproj and restore as distinct layers
+COPY *.sln .
+COPY BoxOfficeInitiative/*.csproj ./BoxOfficeInitiative/
+COPY BoxOfficeInitiative.Tests/*.csproj ./BoxOfficeInitiative.Tests/
+RUN dotnet restore
+
+# copy everything else and build app
+COPY BoxOfficeInitiative/. ./BoxOfficeInitiative/
+RUN dotnet publish -c Release -o out
+
+# unit_testrunner target for running unit tests
+FROM build as unit_testrunner
+ENV RESULT_FILE=/results/test_results.trx
+COPY BoxOfficeInitiative.Tests/ ./BoxOfficeInitiative.Tests/
+WORKDIR /app/BoxOfficeInitiative.Tests
+RUN dotnet build
+ENTRYPOINT dotnet test --logger\:trx\;LogFileName=$RESULT_FILE
+
+# runtime target
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
+WORKDIR /app
+COPY --from=build /app/out ./
+ENTRYPOINT ["dotnet", "BoxOfficeInitiative.dll"]


### PR DESCRIPTION
Add a dockerfile containing two targets to the base directory. The two
targets are `unit_testrunner` and `runtime`.

Building (with `docker build`) with argument `--target unit_testrunner`
will build an image which runs tests only on start up in a container.

Building with argument `--target runtime` will build an image which runs
the project on start up in a container.

Add github action to trigger jenkins rebuild on merging a pull request