### PR TITLE
Fix Github Action

### DIFF
--- a/.github/workflows/jenkins_build.yml
+++ b/.github/workflows/jenkins_build.yml
@@ -1,6 +1,9 @@
 name: Trigger Jenkins dev CI
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [closed]
+
 jobs:
 
   build:


### PR DESCRIPTION
Fix for github action to trigger Jenkins job - now works when PR is
closed (and also only if it was merged).